### PR TITLE
kubernetes/metricstack-exporter-prom-grafana: initial commit

### DIFF
--- a/kubernetes/metricstack-exporter-prom-grafana/.gitignore
+++ b/kubernetes/metricstack-exporter-prom-grafana/.gitignore
@@ -1,0 +1,20 @@
+# k3s data
+/data
+
+# generated kubeconfig file
+/kubeconfig.yaml
+
+# Terraform providers
+/.terraform
+
+# Terraform state
+/terraform.tfstate
+/terraform.tfstate.*.backup
+/terraform.tfstate.backup
+/.terraform.lock.hcl
+
+# Terraform variables
+/terraform.tfvars
+
+# Terraform lock info
+/.terraform.tfstate.lock.info

--- a/kubernetes/metricstack-exporter-prom-grafana/Makefile
+++ b/kubernetes/metricstack-exporter-prom-grafana/Makefile
@@ -1,0 +1,19 @@
+TF_CMD := tofu
+
+help: ## Show this help message
+	@grep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+run: ## Start the k3s cluster and apply the example
+	$(MAKE) start
+	$(TF_CMD) init
+	$(TF_CMD) apply -auto-approve
+
+start: ## Start the k3s cluster (does not create the example)
+	docker compose up -d --wait
+
+stop: ## Stop the k3s cluster
+	docker compose down
+
+reset: ## Stop and remove all data
+	docker compose down -t0
+	sudo rm -rf data/

--- a/kubernetes/metricstack-exporter-prom-grafana/README.md
+++ b/kubernetes/metricstack-exporter-prom-grafana/README.md
@@ -1,0 +1,10 @@
+# Working with metrics using Prometheus, Grafana, and Alertmanager
+
+This exercise showcases how a "metrics stack" can be built using
+Prometheus, Grafana, and Alertmanager. The stack is deployed on a
+Kubernetes cluster and can be accessed via a gateway API.
+
+
+## Lessons Learned
+
+Unrelated to the metrics stack, I ran into issues with HTTPRoute resources that used regular expressions when using Traefik and Gateway API. I switched to using Nginx Gateway Fabric instead, and it worked as expected.

--- a/kubernetes/metricstack-exporter-prom-grafana/docker-compose.yml
+++ b/kubernetes/metricstack-exporter-prom-grafana/docker-compose.yml
@@ -1,0 +1,43 @@
+---
+services:
+  server:
+    image: rancher/k3s:v1.32.1-k3s1
+    tmpfs:
+      - /run
+      - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    restart: unless-stopped
+    volumes:
+      - ./data/k3s-server:/var/lib/rancher/k3s
+      - ./data/persistent-volumes:/opt/local-path-provisioner
+      - .:/output
+    ports:
+      - 6443:6443    # Kubernetes API Server
+      - 80:30080     # Nginx Gateway Fabric
+    # prometheus fails to start unless the root filesystem is shareable
+    # see https://github.com/k3d-io/k3d/issues/1063
+    entrypoint:
+      - sh
+      - -c
+      - >-
+        mount --make-rshared / &&
+        k3s server \
+          --disable=metrics-server \
+          --disable=traefik \
+          --disable=servicelb \
+          --node-name=example
+    environment:
+      - K3S_TOKEN=example
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    healthcheck:
+      test: ["CMD", "kubectl", "get", "--raw=/readyz"]
+      start_period: 1s
+      interval: 1s
+      timeout: 1s
+      retries: 10

--- a/kubernetes/metricstack-exporter-prom-grafana/main.tf
+++ b/kubernetes/metricstack-exporter-prom-grafana/main.tf
@@ -1,0 +1,271 @@
+##
+# This example shows a "metric stack" deployment on Kubernetes using Helm.
+#
+# It deploys Nginx Gateway Fabric, Prometheus, Node Exporter,
+# Blackbox Exporter, and Grafana.
+##
+
+## Inputs
+
+## Required Providers
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
+  }
+}
+
+## Provider Configuration
+
+provider "helm" {
+  kubernetes {
+    config_path = "${path.module}/kubeconfig.yaml"
+  }
+}
+
+provider "kubectl" {
+  config_path = "${path.module}/kubeconfig.yaml"
+}
+
+## Resources
+
+##
+# Gateway API CRDs deploy using Helm
+# - Required for Nginx Gateway Fabric
+# @see https://artifacthub.io/packages/helm/portefaix-hub/gateway-api-crds
+##
+resource "helm_release" "gateway-api" {
+  name       = "gateway-api"
+  repository = "https://charts.portefaix.xyz/"
+  chart      = "gateway-api-crds"
+  version    = "1.2.1"
+}
+
+##
+# Nginx Gateway Fabric deploy using Helm
+# @see https://docs.nginx.com/nginx-gateway-fabric/installation/installing-ngf/helm/
+# @see https://github.com/nginx/nginx-gateway-fabric/pkgs/container/charts%2Fnginx-gateway-fabric
+# Compatibility matrix between Nginx Gateway Fabric and Gateway API versions
+# @see https://github.com/nginx/nginx-gateway-fabric/blob/v1.5.1/README.md#technical-specifications
+##
+resource "helm_release" "nginx-gateway-fabric" {
+  depends_on = [helm_release.gateway-api]
+  name       = "nginx-gateway-fabric"
+  repository = "oci://ghcr.io/nginx/charts"
+  chart      = "nginx-gateway-fabric"
+  version    = "2.0.1"
+
+  values = [
+    # @see https://github.com/nginx/nginx-gateway-fabric/blob/main/charts/nginx-gateway-fabric/values.yaml
+    yamlencode({
+      nginx = {
+        service = {
+          type = "NodePort"
+
+          nodePorts = [
+            {
+              port         = 30080 # external port
+              listenerPort = 80    # service port for internal traffic
+            }
+          ]
+        }
+      }
+    })
+  ]
+}
+
+##
+# Default gateway for our services
+#
+# This gateway resource represents traffic to Nginx Gateway Fabric
+# on port 80. It will be used by http routes to inform Nginx Gateway
+# Fabric how and where to route traffic.
+##
+resource "kubectl_manifest" "gateway" {
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name = "nginx-gateway"
+    }
+    spec = {
+      gatewayClassName = "nginx"
+      listeners = [
+        {
+          name     = "http"
+          protocol = "HTTP"
+          port     = 80
+        }
+      ]
+    }
+  })
+
+  depends_on = [
+    helm_release.gateway-api
+  ]
+}
+
+##
+# Prometheus: A powerful open-source monitoring and alerting toolkit.
+# @see https://prometheus.io/
+# @see https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus
+##
+
+resource "helm_release" "prometheus" {
+  name       = "prometheus"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "prometheus"
+  version    = "27.20.0"
+
+  # @see https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml
+  values = [
+    yamlencode({
+      prometheus-pushgateway = {
+        enabled = false
+      }
+
+      kube-state-metrics = {
+        enabled = false
+      }
+    })
+  ]
+}
+
+##
+# Http Route for Prometheus
+#
+# This route will direct traffic to the Prometheus server based on the
+# host header.
+##
+resource "kubectl_manifest" "http_route_prometheus" {
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name = "prometheus"
+    }
+    spec = {
+      parentRefs = [{ name = "nginx-gateway" }]
+      rules = [{
+        matches = [{
+          headers = [{
+            name  = "Host"
+            type  = "RegularExpression"
+            value = "prometheus\\..+"
+          }]
+        }]
+        backendRefs = [{
+          name = "prometheus-server"
+          port = 80
+        }]
+      }]
+    }
+  })
+
+  depends_on = [
+    helm_release.gateway-api
+  ]
+}
+
+##
+# Http Route for Alertmanager (installed with the Prometheus Helm chart)
+#
+# This route will direct traffic to the Alertmanager server based on the
+# host header.
+##
+resource "kubectl_manifest" "http_route_alertmanager" {
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name = "alertmanager"
+    }
+    spec = {
+      parentRefs = [{ name = "nginx-gateway" }]
+      rules = [{
+        matches = [{
+          headers = [{
+            name  = "Host"
+            type  = "RegularExpression"
+            value = "alertmanager\\..+"
+          }]
+        }]
+        backendRefs = [{
+          name = "prometheus-alertmanager"
+          port = 9093
+        }]
+      }]
+    }
+  })
+
+  depends_on = [
+    helm_release.gateway-api
+  ]
+}
+
+
+##
+# Grafana: visualization platform for observability and data analytics
+#
+# @see https://grafana.com/
+# @see https://github.com/grafana/helm-charts/tree/main/charts/grafana
+##
+resource "helm_release" "grafana" {
+  name       = "grafana"
+  repository = "https://grafana.github.io/helm-charts/"
+  chart      = "grafana"
+  version    = "9.2.7"
+
+  values = [
+    # @see https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+    yamlencode({
+      adminUser     = "admin"
+      adminPassword = "admin"
+    })
+  ]
+}
+
+##
+# Http Route for Grafana
+#
+# This route will direct traffic to the Grafana server based on the
+# host header.
+##
+resource "kubectl_manifest" "http_route_grafana" {
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name = "grafana"
+    }
+    spec = {
+      parentRefs = [{ name = "nginx-gateway" }]
+      rules = [{
+        matches = [{
+          headers = [{
+            name  = "Host"
+            type  = "RegularExpression"
+            value = "grafana\\..+"
+          }]
+        }]
+        backendRefs = [{
+          name = "grafana"
+          port = 80
+        }]
+      }]
+    }
+  })
+
+  depends_on = [
+    helm_release.gateway-api
+  ]
+}


### PR DESCRIPTION
Next steps:
  - Configure grafana to use prometheus as a data source
  - Configure grafana to use alertmanager as a data source
  - Add node exporter dashboard(s) to grafana
  - Add alertmanager dashboard to grafana
  - Add Blackbox exporter helm chart to the cluster
  - Add Blackbox exporter dashboard to grafana
  - Add alert rules to prometheus for node exporter metrics
  - Add alert rules to prometheus for Blackbox exporter metrics