### PR TITLE
kubernetes/cloudflare-tunnel: initial commit

### DIFF
--- a/kubernetes/cloudflare-tunnel/.gitignore
+++ b/kubernetes/cloudflare-tunnel/.gitignore
@@ -1,0 +1,20 @@
+# k3s data
+/data
+
+# generated kubeconfig file
+/kubeconfig.yaml
+
+# Terraform providers
+/.terraform
+
+# Terraform state
+/terraform.tfstate
+/terraform.tfstate.*.backup
+/terraform.tfstate.backup
+/.terraform.lock.hcl
+
+# Terraform variables
+/*.tfvars
+
+# Terraform lock info
+/.terraform.tfstate.lock.info

--- a/kubernetes/cloudflare-tunnel/Makefile
+++ b/kubernetes/cloudflare-tunnel/Makefile
@@ -1,0 +1,19 @@
+TF_CMD := $(shell command -v tofu >/dev/null 2>&1 && echo tofu || echo terraform)
+
+help: ## Show this help message
+	@grep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+run: ## Start the k3s cluster and apply the example
+	$(MAKE) start
+	$(TF_CMD) init
+	$(TF_CMD) apply -auto-approve
+
+start: ## Start the k3s cluster (does not create the example)
+	docker compose up -d --wait
+
+stop: ## Stop the k3s cluster
+	docker compose down
+
+reset: ## Stop and remove all data
+	docker compose down -t0
+	sudo rm -rf data/

--- a/kubernetes/cloudflare-tunnel/README.md
+++ b/kubernetes/cloudflare-tunnel/README.md
@@ -1,0 +1,7 @@
+# Using Cloudflare Tunnel to expose services in Kubernetes
+
+This example shows how Cloudflare Tunnel can be deployed into a Kubernetes cluster to expose services securely to the internet.
+
+## Context
+
+I am in the process of migrating my home lab to Kubernetes. I have a number of services that I want to expose to the internet without directly exposing my home IP address. Cloudflare Tunnel provides a secure way to do this by creating an outbound connection from my Kubernetes cluster to Cloudflare's network.

--- a/kubernetes/cloudflare-tunnel/cloudflare-tunnel.tf
+++ b/kubernetes/cloudflare-tunnel/cloudflare-tunnel.tf
@@ -1,0 +1,367 @@
+##
+# This example shows how Cloudflare Tunnel can be deployed into a
+# Kubernetes cluster to expose services securely to the internet.
+##
+
+## Inputs
+
+variable "cloudflare_api_token" {
+  description = <<-EOT
+    Cloudflare API Token with permissions to manage Tunnels
+
+    Required permissions:
+    - Account: Cloudflare Tunnel: Edit
+  EOT
+  type        = string
+  sensitive   = true
+}
+
+variable "cloudflare_zone" {
+  description = "Cloudflare Zone (domain)"
+  type        = string
+}
+
+variable "cloudflare_account_id" {
+  description = "Cloudflare Account ID"
+  type        = string
+}
+
+variable "cloudflare_tunnel_name" {
+  description = "Cloudflare Tunnel Name"
+  type        = string
+}
+
+## Required Providers
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}
+
+## Provider Configuration
+
+provider "helm" {
+  kubernetes {
+    config_path = "${path.module}/kubeconfig.yaml"
+  }
+}
+
+provider "kubectl" {
+  config_path = "${path.module}/kubeconfig.yaml"
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+## Resources
+
+
+data "cloudflare_zone" "zone" {
+  filter = {
+    name = var.cloudflare_zone
+  }
+}
+
+# @todo create cloudflare resources to create the tunnel and its routes
+
+resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnel" {
+  account_id = var.cloudflare_account_id
+  name       = var.cloudflare_tunnel_name
+  config_src = "cloudflare"
+}
+
+data "cloudflare_zero_trust_tunnel_cloudflared_token" "tunnel_token" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.tunnel.id
+}
+
+resource "cloudflare_dns_record" "record" {
+  zone_id = data.cloudflare_zone.zone.zone_id
+  name    = "tunnel"
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.tunnel.id}.cfargotunnel.com"
+  type    = "CNAME"
+  ttl     = 1
+  proxied = true
+}
+
+resource "cloudflare_zero_trust_tunnel_cloudflared_config" "tunnel_config" {
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.tunnel.id
+  account_id = var.cloudflare_account_id
+  config = {
+    ingress = [
+      {
+        hostname = "tunnel.${var.cloudflare_zone}"
+        service  = "http://nginx-gateway-nginx.default.svc.cluster.local"
+      },
+      {
+        service = "http_status:404"
+      }
+    ]
+  }
+}
+
+resource "kubectl_manifest" "secret" {
+  yaml_body = yamlencode({
+    apiVersion = "v1"
+    kind       = "Secret"
+    metadata = {
+      name = "cloudflare-tunnel-secret"
+    }
+    type = "Opaque"
+    data = {
+      # Base64 encoded token
+      tunnel-token = base64encode(data.cloudflare_zero_trust_tunnel_cloudflared_token.tunnel_token.token)
+    }
+  })
+}
+
+
+# @see https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/deployment-guides/kubernetes/
+resource "kubectl_manifest" "deployment" {
+  depends_on = [kubectl_manifest.secret]
+  yaml_body = yamlencode({
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = "cloudflared-deployment"
+      namespace = "default"
+    }
+    spec = {
+      replicas = 1
+      selector = {
+        matchLabels = {
+          pod = "cloudflared"
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            pod = "cloudflared"
+          }
+        }
+        spec = {
+          securityContext = {
+            sysctls = [
+              # Allows ICMP traffic (ping, traceroute) to resources behind cloudflared.
+              {
+                name  = "net.ipv4.ping_group_range"
+                value = "65532 65532"
+              }
+            ]
+          }
+          containers = [
+            {
+              image = "cloudflare/cloudflared:latest"
+              name  = "cloudflared"
+              env = [
+                # Defines an environment variable for the tunnel token.
+                {
+                  name = "TUNNEL_TOKEN"
+                  valueFrom = {
+                    secretKeyRef = {
+                      name = "cloudflare-tunnel-secret"
+                      key  = "tunnel-token"
+                    }
+                  }
+                }
+              ]
+              command = [
+                # Configures tunnel run parameters
+                "cloudflared",
+                "tunnel",
+                "--no-autoupdate",
+                "--loglevel",
+                "debug",
+                "--metrics",
+                "0.0.0.0:2000",
+                "run"
+              ]
+              livenessProbe = {
+                httpGet = {
+                  # Cloudflared has a /ready endpoint which returns 200 if and only if
+                  # it has an active connection to Cloudflare's network.
+                  path = "/ready"
+                  port = 2000
+                }
+                failureThreshold    = 1
+                initialDelaySeconds = 10
+                periodSeconds       = 10
+              }
+            }
+          ]
+        }
+      }
+    }
+  })
+}
+
+
+##
+# Gateway API: a set of resources for managing service networking in
+# Kubernetes
+#
+# @see https://gateway-api.sigs.k8s.io/
+# @see https://github.com/wiremind/wiremind-helm-charts
+# @see https://artifacthub.io/packages/helm/wiremind/gateway-api-crds
+##
+resource "helm_release" "gateway-api" {
+  name       = "gateway-api"
+  repository = "https://wiremind.github.io/wiremind-helm-charts"
+  chart      = "gateway-api-crds"
+  version    = "1.3.0"
+}
+
+##
+# Nginx Gateway Fabric
+#
+# Compatibility matrix between Nginx Gateway Fabric and Gateway API versions
+# @see https://github.com/nginx/nginx-gateway-fabric/blob/main/README.md#technical-specifications
+#
+# @see https://docs.nginx.com/nginx-gateway-fabric/installation/installing-ngf/helm/
+# @see https://github.com/nginx/nginx-gateway-fabric/pkgs/container/charts%2Fnginx-gateway-fabric
+##
+resource "helm_release" "nginx-gateway-fabric" {
+  depends_on = [helm_release.gateway-api]
+
+  name       = "nginx-gateway-fabric"
+  repository = "oci://ghcr.io/nginx/charts"
+  chart      = "nginx-gateway-fabric"
+  version    = "2.1.1"
+
+  values = [
+    # @see https://github.com/nginx/nginx-gateway-fabric/blob/main/charts/nginx-gateway-fabric/values.yaml
+    yamlencode({
+      nginx = {
+        service = {
+          type = "NodePort"
+          nodePorts = [
+            {
+              port         = 30080
+              listenerPort = 80
+            }
+          ]
+        }
+      }
+    })
+  ]
+}
+
+resource "kubectl_manifest" "gateway" {
+  depends_on = [helm_release.nginx-gateway-fabric]
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "Gateway"
+    metadata = {
+      name = "nginx-gateway"
+    }
+    spec = {
+      gatewayClassName = "nginx"
+      listeners = [
+        {
+          name     = "http"
+          protocol = "HTTP"
+          port     = 80
+        }
+      ]
+    }
+  })
+}
+
+resource "kubectl_manifest" "httproute" {
+  depends_on = [kubectl_manifest.gateway]
+  yaml_body = yamlencode({
+    apiVersion = "gateway.networking.k8s.io/v1"
+    kind       = "HTTPRoute"
+    metadata = {
+      name = "example-httproute"
+    }
+    spec = {
+      parentRefs = [
+        {
+          name        = "nginx-gateway"
+          sectionName = "http"
+        }
+      ]
+      rules = [
+        {
+          matches = [
+            {
+              path = {
+                value = "/"
+              }
+            }
+          ]
+          backendRefs = [
+            {
+              name = "example-service"
+              port = 80
+            }
+          ]
+        }
+      ]
+    }
+  })
+}
+
+resource "kubectl_manifest" "service" {
+  yaml_body = yamlencode({
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name = "example-service"
+    }
+    spec = {
+      selector = {
+        app = "example-app"
+      }
+      ports = [
+        {
+          protocol   = "TCP"
+          port       = 80
+          targetPort = 80
+        }
+      ]
+    }
+  })
+}
+
+resource "kubectl_manifest" "pod" {
+  yaml_body = yamlencode({
+    apiVersion = "v1"
+    kind       = "Pod"
+    metadata = {
+      name = "example-app"
+      labels = {
+        app = "example-app"
+      }
+    }
+    spec = {
+      containers = [
+        {
+          name  = "example-container"
+          image = "nginx:latest"
+          ports = [
+            {
+              containerPort = 80
+            }
+          ]
+        }
+      ]
+    }
+  })
+}

--- a/kubernetes/cloudflare-tunnel/cloudflare-tunnel.tf
+++ b/kubernetes/cloudflare-tunnel/cloudflare-tunnel.tf
@@ -77,7 +77,6 @@ data "cloudflare_zone" "zone" {
   }
 }
 
-# @todo create cloudflare resources to create the tunnel and its routes
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "tunnel" {
   account_id = var.cloudflare_account_id

--- a/kubernetes/cloudflare-tunnel/docker-compose.yml
+++ b/kubernetes/cloudflare-tunnel/docker-compose.yml
@@ -1,0 +1,38 @@
+---
+services:
+  server:
+    image: rancher/k3s:v1.33.4-k3s1
+    tmpfs:
+      - /run
+      - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    restart: unless-stopped
+    volumes:
+      - ./data/k3s-server:/var/lib/rancher/k3s
+      - ./data/persistent-volumes:/opt/local-path-provisioner
+      - .:/output
+    ports:
+      - 6443:6443    # Kubernetes API Server
+      - 30080:30080  # HTTP NodePort
+      - 30443:30443  # HTTPS NodePort
+    command:
+      - server
+      - --disable=metrics-server
+      - --disable=traefik
+      - --disable=servicelb
+      - --node-name=example
+    environment:
+      - K3S_TOKEN=example
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    healthcheck:
+      test: ["CMD", "kubectl", "get", "--raw=/readyz"]
+      start_period: 1s
+      interval: 1s
+      timeout: 1s
+      retries: 10


### PR DESCRIPTION
This pull request introduces an example for deploying a Cloudflare Tunnel to securely expose services running in a Kubernetes cluster, along with supporting infrastructure-as-code and local development tooling. The changes include a complete Terraform configuration for provisioning Cloudflare and Kubernetes resources, Docker Compose setup for a local k3s cluster, a Makefile for workflow automation, and documentation for users.

The most important changes are:

**Cloudflare Tunnel and Kubernetes Infrastructure (Terraform):**
* Added `cloudflare-tunnel.tf`, a complete Terraform configuration that provisions a Cloudflare Tunnel, DNS records, related secrets, and deploys the `cloudflared` agent in Kubernetes. It also sets up Gateway API resources, Nginx Gateway Fabric, and an example application service and route.

**Local Kubernetes Cluster Setup:**
* Added `docker-compose.yml` to launch a local k3s-based Kubernetes cluster, pre-configured for the example, including persistent storage and necessary port mappings.

**Developer Tooling and Automation:**
* Added a `Makefile` with commands to start/stop/reset the local cluster and automate Terraform workflows, supporting both Terraform and OpenTofu.
* Added a `.gitignore` to exclude generated files, Terraform state, and sensitive data from version control.

**Documentation:**
* Added a `README.md` describing the purpose of the example and providing context for users migrating home lab services to Kubernetes with secure internet exposure via Cloudflare Tunnel.