### PR TITLE
kubernetes/ansible-awx: initial commit

### DIFF
--- a/kubernetes/ansible-awx/.gitignore
+++ b/kubernetes/ansible-awx/.gitignore
@@ -1,0 +1,20 @@
+# k3s data
+/data
+
+# generated kubeconfig file
+/kubeconfig.yaml
+
+# Terraform providers
+/.terraform
+
+# Terraform state
+/terraform.tfstate
+/terraform.tfstate.*.backup
+/terraform.tfstate.backup
+/.terraform.lock.hcl
+
+# Terraform variables
+/*.tfvars
+
+# Terraform lock info
+/.terraform.tfstate.lock.info

--- a/kubernetes/ansible-awx/Makefile
+++ b/kubernetes/ansible-awx/Makefile
@@ -1,0 +1,19 @@
+TF_CMD := $(shell command -v tofu >/dev/null 2>&1 && echo tofu || echo terraform)
+
+help: ## Show this help message
+	@grep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+run: ## Start the k3s cluster and apply the example
+	$(MAKE) start
+	$(TF_CMD) init
+	$(TF_CMD) apply -auto-approve
+
+start: ## Start the k3s cluster (does not create the example)
+	docker compose up -d --wait
+
+stop: ## Stop the k3s cluster
+	docker compose down
+
+reset: ## Stop and remove all data
+	docker compose down -t0
+	sudo rm -rf data/

--- a/kubernetes/ansible-awx/README.md
+++ b/kubernetes/ansible-awx/README.md
@@ -1,0 +1,7 @@
+# Running Ansible AWX on Kubernetes
+
+This exercise demonstrates how to deploy Ansible AWX on a Kubernetes cluster.
+
+## Context
+
+I have experience using Docker to run Ansible playbooks locally and in CI/CD pipelines in a containerized manner, but have not yet explored solutions that would allow scaling out how Ansible is run. I have heard mixed reviews of Ansible AWX, but want to play with it to see if it might be a good fit for my needs.

--- a/kubernetes/ansible-awx/ansible-awx.tf
+++ b/kubernetes/ansible-awx/ansible-awx.tf
@@ -1,0 +1,111 @@
+##
+# This example shows how Cert Manager can be deployed in a Kubernetes
+# cluster
+##
+
+## Inputs
+
+variable "admin_user" {
+  type        = string
+  description = "Admin user for AWX"
+}
+
+variable "admin_email" {
+  type        = string
+  description = "Admin email for AWX"
+}
+
+variable "admin_password" {
+  type        = string
+  description = "Admin password for AWX"
+  sensitive   = true
+}
+
+## Required Providers
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
+  }
+}
+
+## Provider Configuration
+
+provider "helm" {
+  kubernetes {
+    config_path = "${path.module}/kubeconfig.yaml"
+  }
+}
+
+provider "kubectl" {
+  config_path = "${path.module}/kubeconfig.yaml"
+}
+
+## Resources
+
+##
+# AWX Operator: an operator for running AWX on Kubernetes
+#
+# @see https://github.com/ansible/awx-operator
+# @see https://github.com/ansible-community/awx-operator-helm
+##
+resource "helm_release" "awx-operator" {
+  name       = "my-awx-operator"
+  repository = "https://ansible-community.github.io/awx-operator-helm/"
+  chart      = "awx-operator"
+  version    = "3.2.0"
+
+  # @see https://github.com/ansible-community/awx-operator-helm/blob/main/charts/awx-operator/values.yaml
+  values = [
+
+  ]
+}
+
+resource "kubectl_manifest" "awx-admin-password-secret" {
+  yaml_body = yamlencode({
+    apiVersion = "v1"
+    kind       = "Secret"
+    metadata = {
+      name = "awx-admin-password"
+    }
+    stringData = {
+      password = var.admin_password
+    }
+  })
+}
+
+##
+# AWX: web UI for Ansible
+#
+# @see https://github.com/ansible/awx
+# @see https://ansible.readthedocs.io/projects/awx-operator/en/latest/
+##
+resource "kubectl_manifest" "awx-instance" {
+  depends_on = [helm_release.awx-operator, kubectl_manifest.awx-admin-password-secret]
+
+  yaml_body = yamlencode({
+    apiVersion = "awx.ansible.com/v1beta1"
+    kind       = "AWX"
+    metadata = {
+      name = "awx-demo"
+    }
+    spec = {
+      service_type  = "nodeport"
+      nodeport_port = 30080
+
+
+      admin_user            = var.admin_user
+      admin_email           = var.admin_email
+      admin_password_secret = "awx-admin-password"
+    }
+  })
+}

--- a/kubernetes/ansible-awx/ansible-awx.tf
+++ b/kubernetes/ansible-awx/ansible-awx.tf
@@ -1,6 +1,6 @@
 ##
-# This example shows how Cert Manager can be deployed in a Kubernetes
-# cluster
+# This example shows how AWX (Ansible AWX and its operator) can be deployed in a Kubernetes
+# cluster using Terraform, Helm, and Kubectl providers.
 ##
 
 ## Inputs

--- a/kubernetes/ansible-awx/docker-compose.yml
+++ b/kubernetes/ansible-awx/docker-compose.yml
@@ -1,0 +1,38 @@
+---
+services:
+  server:
+    image: rancher/k3s:v1.33.4-k3s1
+    tmpfs:
+      - /run
+      - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    restart: unless-stopped
+    volumes:
+      - ./data/k3s-server:/var/lib/rancher/k3s
+      - ./data/persistent-volumes:/opt/local-path-provisioner
+      - .:/output
+    ports:
+      - 6443:6443    # Kubernetes API Server
+      - 30080:30080  # HTTP NodePort
+      - 30443:30443  # HTTPS NodePort
+    command:
+      - server
+      - --disable=metrics-server
+      - --disable=traefik
+      - --disable=servicelb
+      - --node-name=example
+    environment:
+      - K3S_TOKEN=example
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    healthcheck:
+      test: ["CMD", "kubectl", "get", "--raw=/readyz"]
+      start_period: 1s
+      interval: 1s
+      timeout: 1s
+      retries: 10


### PR DESCRIPTION
This pull request introduces a complete setup for running Ansible AWX on a local Kubernetes cluster using k3s and Terraform (or OpenTofu). It adds all necessary configuration, automation scripts, and documentation to make it easy to spin up, manage, and clean up a demo environment for AWX. The changes are grouped into environment setup, infrastructure as code, automation, and documentation.

**Environment setup:**

* Added `docker-compose.yml` to run a local k3s Kubernetes cluster with persistent volumes and exposed ports for AWX access.

**Infrastructure as code:**

* Introduced `ansible-awx.tf`, a Terraform configuration that deploys the AWX Operator and an AWX instance, including secrets management and required providers.

**Automation and developer tooling:**

* Added a `Makefile` with commands to start/stop the cluster, apply Terraform configuration, and clean up resources, supporting both `terraform` and `tofu` CLIs.
* Created a `.gitignore` to exclude generated files, Terraform state, and Kubernetes configuration from version control.

**Documentation:**

* Added a `README.md` describing the purpose and context for deploying Ansible AWX on Kubernetes.