### PR TITLE
user-scripts/hacker-news-title: initial commit

### DIFF
--- a/user-scripts/hacker-news-title/README.md
+++ b/user-scripts/hacker-news-title/README.md
@@ -1,0 +1,3 @@
+# User Script: hn.premii.com Title Catcher
+
+This user script captures the titles of articles on the Hacker News client site [hn.premii.com](https://hn.premii.com) and sets them as the document title. This allows users to see the current article title in the browser tab, enhancing navigation and usability.

--- a/user-scripts/hacker-news-title/hacker-news-title.user.js
+++ b/user-scripts/hacker-news-title/hacker-news-title.user.js
@@ -5,24 +5,28 @@
 // @run-at           document-idle
 // ==/UserScript==
 
+const MAX_TITLE_LENGTH = 50;
+const TITLE_SELECTOR = '.page-comments .title';
+const PAGE_SELECTOR = '.pages-container';
+
 (() => {
     const setTitle = (title) => {
-        if (title.length > 50) {
-            title = title.substring(0, 50) + "...";
+        if (title.length > MAX_TITLE_LENGTH) {
+            title = title.substring(0, MAX_TITLE_LENGTH) + "...";
         }
 
         document.title = title + " | HN";
     };
 
     const checkForTitle = () => {
-        const titleEl = document.querySelector('.page-comments .title');
+        const titleEl = document.querySelector(TITLE_SELECTOR);
 
         if (titleEl) {
             setTitle(titleEl.innerText);
         }
     };
 
-    const pageEl = document.querySelector('.pages-container');
+    const pageEl = document.querySelector(PAGE_SELECTOR);
     if (!pageEl) {
         console.warn('HN Title Catcher: No page element found, aborting.');
         return;

--- a/user-scripts/hacker-news-title/hacker-news-title.user.js
+++ b/user-scripts/hacker-news-title/hacker-news-title.user.js
@@ -22,12 +22,16 @@
         }
     };
 
-    const observer = new MutationObserver(checkForTitle);
-
     const pageEl = document.querySelector('.pages-container');
+    if (!pageEl) {
+        console.warn('HN Title Catcher: No page element found, aborting.');
+        return;
+    }
+
+    const observer = new MutationObserver(checkForTitle);
     observer.observe(pageEl, {
         childList: true,
         subtree: true
     });
-    checkForTitle([], observer);
+    checkForTitle();
 })();

--- a/user-scripts/hacker-news-title/hacker-news-title.user.js
+++ b/user-scripts/hacker-news-title/hacker-news-title.user.js
@@ -1,0 +1,33 @@
+// ==UserScript==
+// @name             Hacker News Title Catcher
+// @match            https://hn.premii.com/*
+// @version          1.0
+// @run-at           document-idle
+// ==/UserScript==
+
+(() => {
+    const setTitle = (title) => {
+        if (title.length > 50) {
+            title = title.substring(0, 50) + "...";
+        }
+
+        document.title = title + " | HN";
+    };
+
+    const checkForTitle = () => {
+        const titleEl = document.querySelector('.page-comments .title');
+
+        if (titleEl) {
+            setTitle(titleEl.innerText);
+        }
+    };
+
+    const observer = new MutationObserver(checkForTitle);
+
+    const pageEl = document.querySelector('.pages-container');
+    observer.observe(pageEl, {
+        childList: true,
+        subtree: true
+    });
+    checkForTitle([], observer);
+})();


### PR DESCRIPTION
This pull request introduces a new user script that enhances the usability of the Hacker News client site at hn.premii.com by dynamically updating the browser tab's title to reflect the current article's title. This makes navigation and tab management easier for users.

New user script for dynamic tab titles:

* Added `hacker-news-title.user.js`, a user script that observes the page for article title changes and updates the document title accordingly, truncating long titles and appending " | HN".
* Added a `README.md` file describing the purpose and functionality of the user script.