### PR TITLE
 kubernetes/grafana: initial commit 

### DIFF
--- a/kubernetes/grafana/.gitignore
+++ b/kubernetes/grafana/.gitignore
@@ -1,0 +1,20 @@
+# k3s data
+/data
+
+# generated kubeconfig file
+/kubeconfig.yaml
+
+# Terraform providers
+/.terraform
+
+# Terraform state
+/terraform.tfstate
+/terraform.tfstate.*.backup
+/terraform.tfstate.backup
+/.terraform.lock.hcl
+
+# Terraform variables
+/terraform.tfvars
+
+# Terraform lock info
+/.terraform.tfstate.lock.info

--- a/kubernetes/grafana/Makefile
+++ b/kubernetes/grafana/Makefile
@@ -3,12 +3,12 @@ TF_CMD := tofu
 help: ## Show this help message
 	@grep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
 
-run: ## Start the k3s cluster and apply the ollama example
+run: ## Start the k3s cluster and apply the grafana example
 	$(MAKE) start
 	$(TF_CMD) init
 	$(TF_CMD) apply -auto-approve
 
-start: ## Start the k3s cluster (does not create the ollama example)
+start: ## Start the k3s cluster (does not create the grafana example)
 	docker compose up -d --wait
 
 stop: ## Stop the k3s cluster

--- a/kubernetes/grafana/Makefile
+++ b/kubernetes/grafana/Makefile
@@ -1,0 +1,19 @@
+TF_CMD := tofu
+
+help: ## Show this help message
+	@grep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+run: ## Start the k3s cluster and apply the ollama example
+	$(MAKE) start
+	$(TF_CMD) init
+	$(TF_CMD) apply -auto-approve
+
+start: ## Start the k3s cluster (does not create the ollama example)
+	docker compose up -d --wait
+
+stop: ## Stop the k3s cluster
+	docker compose down
+
+reset: ## Stop and remove all data
+	docker compose down -t0
+	sudo rm -rf data/

--- a/kubernetes/grafana/README.md
+++ b/kubernetes/grafana/README.md
@@ -1,13 +1,3 @@
-# Using Victoria Logs in a Kubernetes Cluster
+# Deploying Grafana to Kubernetes through Terraform and Helm
 
-This exercise demonstrates bringing up a Victoria Logs instance in a Kubernetes cluster using the provided Helm chart. It also provisions Vector to collect logs from the cluster and send them to Victoria Logs.
-
-## Context
-
-I have been building out a bare-metal Kubernetes cluster and wanted to set up a centralized logging solution that could handle indexing/querying logs without the overhead of a full ELK stack. I previously evaluated Loki and Victoria Logs using Docker, and found Victoria Logs to fit my needs better due its method of log ingestion and indexing.
-
-## Prerequisites
-
-- Docker Compose
-- kubectl
-- Terraform or OpenTofu
+This exercise showcases how Grafana can be deployed into a Kubernetes cluster using Terraform and Helm. Grafana provides a platform for visualizing metrics and logs from various sources, and is commonly used in conjunction with Prometheus for monitoring.

--- a/kubernetes/grafana/README.md
+++ b/kubernetes/grafana/README.md
@@ -1,0 +1,13 @@
+# Using Victoria Logs in a Kubernetes Cluster
+
+This exercise demonstrates bringing up a Victoria Logs instance in a Kubernetes cluster using the provided Helm chart. It also provisions Vector to collect logs from the cluster and send them to Victoria Logs.
+
+## Context
+
+I have been building out a bare-metal Kubernetes cluster and wanted to set up a centralized logging solution that could handle indexing/querying logs without the overhead of a full ELK stack. I previously evaluated Loki and Victoria Logs using Docker, and found Victoria Logs to fit my needs better due its method of log ingestion and indexing.
+
+## Prerequisites
+
+- Docker Compose
+- kubectl
+- Terraform or OpenTofu

--- a/kubernetes/grafana/docker-compose.yml
+++ b/kubernetes/grafana/docker-compose.yml
@@ -1,0 +1,43 @@
+---
+services:
+  server:
+    image: rancher/k3s:v1.32.1-k3s1
+    tmpfs:
+      - /run
+      - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    restart: unless-stopped
+    volumes:
+      - ./data/k3s-server:/var/lib/rancher/k3s
+      - ./data/persistent-volumes:/opt/local-path-provisioner
+      - .:/output
+    ports:
+      - 6443:6443    # Kubernetes API Server
+      - 80:30080     # Grafana
+    # prometheus fails to start unless the root filesystem is shareable
+    # see https://github.com/k3d-io/k3d/issues/1063
+    entrypoint:
+      - sh
+      - -c
+      - >-
+        mount --make-rshared / &&
+        k3s server \
+          --disable=metrics-server \
+          --disable=traefik \
+          --disable=servicelb \
+          --node-name=example
+    environment:
+      - K3S_TOKEN=example
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    healthcheck:
+      test: ["CMD", "kubectl", "get", "--raw=/readyz"]
+      start_period: 1s
+      interval: 1s
+      timeout: 1s
+      retries: 10

--- a/kubernetes/grafana/main.tf
+++ b/kubernetes/grafana/main.tf
@@ -1,0 +1,61 @@
+##
+# This example shows how Grafana can be deployed in a Kubernetes cluster
+##
+
+## Inputs
+
+## Required Providers
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
+  }
+}
+
+## Provider Configuration
+
+provider "helm" {
+  kubernetes {
+    config_path = "${path.module}/kubeconfig.yaml"
+  }
+}
+
+provider "kubectl" {
+  config_path = "${path.module}/kubeconfig.yaml"
+}
+
+## Resources
+
+##
+# Grafana: visualization platform for observability and data analytics
+#
+# @see https://grafana.com/
+# @see https://github.com/grafana/helm-charts/tree/main/charts/grafana
+##
+resource "helm_release" "grafana" {
+  name       = "grafana"
+  repository = "https://grafana.github.io/helm-charts/"
+  chart      = "grafana"
+  version    = "9.2.7"
+
+  values = [
+    # @see https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+    yamlencode({
+      service = {
+        type     = "NodePort"
+        nodePort = 30080
+      }
+      adminUser     = "admin"
+      adminPassword = "admin"
+    })
+  ]
+}


### PR DESCRIPTION
This pull request introduces a reproducible setup for deploying Grafana to a local Kubernetes cluster using Docker Compose, Terraform, and Helm. It adds all the necessary configuration, automation scripts, and documentation to streamline local development and testing of Grafana deployments.

**Infrastructure and automation setup:**

* Added a `docker-compose.yml` file to launch a local k3s-based Kubernetes cluster with appropriate configuration, persistent storage, and exposed ports for the Kubernetes API and Grafana service.
* Introduced a `Makefile` with targets to start, stop, reset the k3s cluster, and automate Terraform initialization and apply steps using the `tofu` command.
* Added a `.gitignore` file to exclude generated data, kubeconfig, and Terraform state/lock files from version control.

**Grafana deployment via Terraform and Helm:**

* Added a `main.tf` Terraform configuration that sets up required providers, configures access to the local cluster, and deploys Grafana using the official Helm chart with basic admin credentials and NodePort service exposure.

**Documentation:**

* Added a `README.md` file describing the purpose of the setup and providing a brief overview of deploying Grafana via Terraform and Helm.