### PR TITLE
 kubernetes/ddns-updater: initial commit 

### DIFF
--- a/kubernetes/ddns-updater/.gitignore
+++ b/kubernetes/ddns-updater/.gitignore
@@ -1,0 +1,21 @@
+# k3s data
+/data
+
+# generated kubeconfig file
+/kubeconfig.yaml
+
+# Terraform providers
+/.terraform
+
+# Terraform state
+/terraform.tfstate
+/terraform.tfstate.*.backup
+/terraform.tfstate.backup
+/.terraform.lock.hcl
+
+# Terraform variables
+/*.auto.tfvars
+/terraform.tfvars
+
+# Terraform lock info
+/.terraform.tfstate.lock.info

--- a/kubernetes/ddns-updater/Makefile
+++ b/kubernetes/ddns-updater/Makefile
@@ -1,0 +1,19 @@
+TF_CMD := $(shell command -v tofu >/dev/null 2>&1 && echo tofu || echo terraform)
+
+help: ## Show this help message
+	@grep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-22s\033[0m %s\n", $$1, $$2}'
+
+run: ## Start the k3s cluster and apply the example
+	$(MAKE) start
+	$(TF_CMD) init
+	$(TF_CMD) apply -auto-approve
+
+start: ## Start the k3s cluster (does not create the example)
+	docker compose up -d --wait
+
+stop: ## Stop the k3s cluster
+	docker compose down
+
+reset: ## Stop and remove all data
+	docker compose down -t0
+	sudo rm -rf data/

--- a/kubernetes/ddns-updater/README.md
+++ b/kubernetes/ddns-updater/README.md
@@ -1,0 +1,20 @@
+# Running ddns-updater in Kubernetes
+
+This exercise demonstrates how ddns-updater can be used with webhook
+providers to update DNS records for domains using Porkbun for DNS.
+
+## Context
+
+I am in the process of migrating my home lab to Kubernetes. I have a
+number of services that I want to expose externally, and I want to use
+dynamic DNS to manage the DNS records for these services. I am using
+Porkbun as my DNS provider, and I want to use ddns-updater to update
+the DNS records automatically when my external IP address changes.
+
+## Notes
+
+Where there's a third-party helm chart available, it appears to rely on
+environment variables for configuration. This means that secrets are
+exposed in the helm release, which is not ideal. I opted to skip helm
+and deploy the application directly using Kubernetes manifests, which
+allows me to use Kubernetes secrets to manage sensitive information.

--- a/kubernetes/ddns-updater/ddns-updater.auto.dist.tfvars
+++ b/kubernetes/ddns-updater/ddns-updater.auto.dist.tfvars
@@ -1,0 +1,4 @@
+ddns_domain = ""
+
+porkbun_api_key    = ""
+porkbun_api_secret = ""

--- a/kubernetes/ddns-updater/ddns-updater.main.tf
+++ b/kubernetes/ddns-updater/ddns-updater.main.tf
@@ -1,0 +1,77 @@
+##
+# This example shows how ddns-updater can be used to manage
+# a dynamic DNS domain using Porkbun as the DNS provider.
+##
+
+## Inputs
+
+variable "ddns_domain" {
+  description = "The DDNS domain to be managed"
+  type        = string
+}
+
+variable "porkbun_api_key" {
+  description = "Porkbun API Key"
+  type        = string
+  sensitive   = true
+}
+
+variable "porkbun_api_secret" {
+  description = "Porkbun API Secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "resolver_address" {
+  description = "The DNS resolver address to use"
+  type        = string
+  default     = "1.1.1.1:53"
+}
+
+## Required Providers
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = "~> 2.0"
+    }
+  }
+}
+
+## Provider Configuration
+
+provider "helm" {
+  kubernetes {
+    config_path = "${path.module}/kubeconfig.yaml"
+  }
+}
+
+provider "kubectl" {
+  config_path = "${path.module}/kubeconfig.yaml"
+}
+
+## Resources
+
+module "ddns_updater" {
+  source           = "./modules/ddns-updater"
+  resolver_address = var.resolver_address
+  service_type     = "NodePort"
+  node_port        = 30080
+
+  settings = [
+    {
+      provider       = "porkbun"
+      domain         = var.ddns_domain
+      api_key        = var.porkbun_api_key
+      secret_api_key = var.porkbun_api_secret
+      ip_version     = "ipv4"
+    }
+  ]
+}

--- a/kubernetes/ddns-updater/docker-compose.yml
+++ b/kubernetes/ddns-updater/docker-compose.yml
@@ -1,0 +1,38 @@
+---
+services:
+  server:
+    image: rancher/k3s:v1.33.4-k3s1
+    tmpfs:
+      - /run
+      - /var/run
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 65535
+        hard: 65535
+    privileged: true
+    restart: unless-stopped
+    volumes:
+      - ./data/k3s-server:/var/lib/rancher/k3s
+      - ./data/persistent-volumes:/opt/local-path-provisioner
+      - .:/output
+    ports:
+      - 6443:6443    # Kubernetes API Server
+      - 30080:30080  # HTTP NodePort
+      - 30443:30443  # HTTPS NodePort
+    command:
+      - server
+      - --disable=metrics-server
+      - --disable=traefik
+      - --disable=servicelb
+      - --node-name=example
+    environment:
+      - K3S_TOKEN=example
+      - K3S_KUBECONFIG_OUTPUT=/output/kubeconfig.yaml
+      - K3S_KUBECONFIG_MODE=666
+    healthcheck:
+      test: ["CMD", "kubectl", "get", "--raw=/readyz"]
+      start_period: 1s
+      interval: 1s
+      timeout: 1s
+      retries: 10

--- a/kubernetes/ddns-updater/docker-compose.yml
+++ b/kubernetes/ddns-updater/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./data/k3s-server:/var/lib/rancher/k3s
-      - ./data/persistent-volumes:/opt/local-path-provisioner
+      - ./data/persistent-volumes:/var/lib/rancher/k3s/storage
       - .:/output
     ports:
       - 6443:6443    # Kubernetes API Server

--- a/kubernetes/ddns-updater/modules/ddns-updater/ddns-updater.module.tf
+++ b/kubernetes/ddns-updater/modules/ddns-updater/ddns-updater.module.tf
@@ -184,12 +184,14 @@ resource "kubectl_manifest" "ddns_updater_service" {
         app = "ddns-updater"
       }
       ports = [
-        {
-          port       = 80
-          targetPort = 8000
-          nodePort   = var.service_type == "NodePort" ? var.node_port : null
-          protocol   = "TCP"
-        }
+        merge(
+          {
+            port       = 80
+            targetPort = 8000
+            protocol   = "TCP"
+          },
+          var.service_type == "NodePort" ? { nodePort = var.node_port } : {}
+        )
       ]
     }
   })

--- a/kubernetes/ddns-updater/modules/ddns-updater/ddns-updater.module.tf
+++ b/kubernetes/ddns-updater/modules/ddns-updater/ddns-updater.module.tf
@@ -1,0 +1,196 @@
+##
+# ddns-updater module: Deploys ddns-updater into a Kubernetes cluster.
+#
+# ddns-updater updates DNS records based on the current IP address of
+# the host.
+##
+
+## Inputs
+
+variable "settings" {
+  description = "The DDNS settings"
+  type        = list(map(string))
+}
+
+variable "resolver_address" {
+  description = "The DNS resolver address to use"
+  type        = string
+  default     = "1.1.1.1:53"
+}
+
+variable "service_type" {
+  description = "The type of Kubernetes Service to create"
+  type        = string
+  default     = "ClusterIP"
+}
+
+variable "node_port" {
+  description = "The node port to use if service_type is NodePort"
+  type        = number
+  default     = 30080
+}
+
+variable "storage_class_name" {
+  description = "The storage class name to use for the PersistentVolumeClaim"
+  type        = string
+  default     = null
+}
+
+## Required Providers
+
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    helm = {
+      source = "hashicorp/helm"
+    }
+    kubectl = {
+      source = "alekc/kubectl"
+    }
+  }
+}
+
+## Resources
+
+# secret
+resource "kubectl_manifest" "ddns_updater_secret" {
+  yaml_body = yamlencode({
+    apiVersion = "v1"
+    kind       = "Secret"
+    metadata = {
+      name = "ddns-updater-secret"
+    }
+    type = "Opaque"
+    data = {
+      config = base64encode(jsonencode({
+        settings = var.settings
+      }))
+    }
+  })
+}
+
+# persistent volume claim
+resource "kubectl_manifest" "ddns_updater_pvc" {
+  yaml_body = yamlencode({
+    apiVersion = "v1"
+    kind       = "PersistentVolumeClaim"
+    metadata = {
+      name = "ddns-updater-pvc"
+    }
+    spec = merge(
+      {
+        accessModes = ["ReadWriteOnce"]
+        resources = {
+          requests = {
+            storage = "10Mi"
+          }
+        }
+      },
+      var.storage_class_name != null ? {
+        storageClassName = var.storage_class_name
+      } : {}
+    )
+  })
+}
+
+# deployment
+
+resource "kubectl_manifest" "ddns_updater_deployment" {
+  depends_on = [
+    kubectl_manifest.ddns_updater_secret,
+    kubectl_manifest.ddns_updater_pvc
+  ]
+
+  yaml_body = yamlencode({
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name = "ddns-updater"
+    }
+    spec = {
+      replicas = 1
+      selector = {
+        matchLabels = {
+          app = "ddns-updater"
+        }
+      }
+      template = {
+        metadata = {
+          labels = {
+            app = "ddns-updater"
+          }
+        }
+        spec = {
+          containers = [
+            {
+              name  = "ddns-updater"
+              image = "qmcgaw/ddns-updater:v2"
+              ports = [
+                {
+                  containerPort = 8000
+                  protocol      = "TCP"
+                }
+              ]
+              volumeMounts = [
+                {
+                  name      = "data"
+                  mountPath = "/updater/data"
+                },
+                {
+                  name      = "ddns-updater-secret"
+                  mountPath = "/updater/data/config.json"
+                  subPath   = "config"
+                }
+              ]
+              env = [
+                {
+                  name  = "RESOLVER_ADDRESS"
+                  value = var.resolver_address
+                }
+              ]
+            }
+          ]
+          volumes = [
+            {
+              name = "data"
+              persistentVolumeClaim = {
+                claimName = "ddns-updater-pvc"
+              }
+            },
+            {
+              name = "ddns-updater-secret"
+              secret = {
+                secretName = "ddns-updater-secret"
+              }
+            }
+          ]
+        }
+      }
+    }
+  })
+}
+
+resource "kubectl_manifest" "ddns_updater_service" {
+  yaml_body = yamlencode({
+    apiVersion = "v1"
+    kind       = "Service"
+    metadata = {
+      name = "ddns-updater"
+    }
+    spec = {
+      type = var.service_type
+      selector = {
+        app = "ddns-updater"
+      }
+      ports = [
+        {
+          port       = 80
+          targetPort = 8000
+          nodePort   = var.service_type == "NodePort" ? var.node_port : null
+          protocol   = "TCP"
+        }
+      ]
+    }
+  })
+}


### PR DESCRIPTION
This pull request introduces a new example for running `ddns-updater` in a Kubernetes environment, with a focus on secure configuration and automation using Terraform. The changes provide a complete setup for deploying `ddns-updater` with Porkbun as the DNS provider, leveraging Kubernetes manifests, Docker Compose for local k3s clusters, and Terraform modules for infrastructure management. The setup prioritizes security by managing secrets with Kubernetes rather than exposing them via Helm values.

The most important changes are:

**Infrastructure as Code & Deployment Automation:**
* Added a Terraform module (`modules/ddns-updater/ddns-updater.module.tf`) to automate the deployment of `ddns-updater` in Kubernetes, including creation of secrets, persistent volume claims, deployments, and services. The module supports configuration for service type, node port, and storage class, and securely passes DDNS settings via Kubernetes secrets.
* Introduced a top-level Terraform configuration (`ddns-updater.main.tf` and `ddns-updater.auto.dist.tfvars`) to manage the deployment, including provider setup, variable definitions for Porkbun credentials, and instantiation of the module. [[1]](diffhunk://#diff-57967e62912dc0ca07a40bf4aa1d9082a1e76e6503052b197aaf455fb1d7750cR1-R77) [[2]](diffhunk://#diff-9bafee88c244915a97c562e81e66093a9ceac20708290c448136a983578e3202R1-R4)

**Local Kubernetes Cluster Setup:**
* Added a `docker-compose.yml` file to run a local k3s (Kubernetes) cluster for testing and development, exposing relevant ports and configuring persistent storage.
* Created a `Makefile` to streamline cluster management and Terraform operations, supporting commands for starting/stopping the cluster, applying Terraform, and resetting the environment.

**Documentation & Project Hygiene:**
* Added a `README.md` explaining the motivation, context, and approach for running `ddns-updater` in Kubernetes, emphasizing the use of Kubernetes secrets over Helm for sensitive data.
* Updated `.gitignore` to exclude generated files, Terraform state, and k3s data directories, ensuring sensitive and transient files are not committed.